### PR TITLE
Make software actually useful

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,10 @@ DHCP parser using nom
 license = "MIT"
 
 [dependencies]
-nom = "*"
-enum_primitive = "*"
+nom = "0.3.11"
+enum_primitive = "0.1.1"
 
 [dependencies.num]
 version = "*"
 default-features = false
 
-[dependencies.rest_easy]
-path = "../rest_easy"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,3 @@
-#![feature(trace_macros)]
-#![feature(ip_addr)]
-#![feature(plugin)]
-
-#[plugin] #[no_link] extern crate rest_easy;
-
 /// DHCP Parsing
 ///
 /// Takes bytes and turns them into Rust datatypes
@@ -84,8 +78,7 @@ pub struct RawMessage<'a> {
     options: Vec<DhcpOption>,
 }
 
-#[allow(dead_code)]
-fn parse_message<'a>(bytes: &'a [u8]) -> Result<RawMessage<'a>> {
+pub fn parse_message<'a>(bytes: &'a [u8]) -> Result<RawMessage<'a>> {
     match _parse_message(bytes) {
         IResult::Done(inp, msg) => {
             if inp.len() > 0 {


### PR DESCRIPTION
Changes that have been applied:

* Removed dependency on rest_easy, as rest_easy fails to compile and
that functionality is now built into cargo using the `check` subcommand
* Add version constraints for all dependencies, as this code does not
compile with recent versions of the nom crate. For now, I have picked
the the version which was latest when the last commit was added to the
repo
* I exported the `parse_message` method.